### PR TITLE
Support omitting strip

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -26,10 +26,17 @@ exports.getResizedImageUrl = (imageUrl, targetSize, actions, transformToken, par
 		throw new Error('Target width and height must be positive integers');
 	}
 
-	return getImageUrl(baseUrl, Object.assign({}, actions, {
-		resize: targetSize,
-		strip: true
-	}), transformToken);
+	actions = Object.assign(
+		{strip: true},
+		actions,
+		{resize: targetSize}
+	);
+
+	if (!actions.strip) {
+		delete actions.strip;
+	}
+
+	return getImageUrl(baseUrl, actions, transformToken);
 
 	function getImageUrl(baseUrl, actions, accessToken) {
 		const url = baseUrl + '?' + actionsToQueryParam(actions);

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -13,7 +13,7 @@ describe('getResizedImageUrl', () => {
 			};
 			const newUrl = getResizedImageUrl(url, targetSize, {}, 'secret');
 
-			assert.deepEqual(newUrl, 'https://smooth-storage-dev.aptoma.no/users/dn/images/986914.jpg?t%5Bresize%5D%5Bwidth%5D=100&t%5Bresize%5D%5Bheight%5D=100&t%5Bstrip%5D=true&accessToken=8d379e42d48a7215c0e17b2c0b28dec1cc563164d0b0f679ee7e19723e908128');
+			assert.deepEqual(newUrl, 'https://smooth-storage-dev.aptoma.no/users/dn/images/986914.jpg?t%5Bstrip%5D=true&t%5Bresize%5D%5Bwidth%5D=100&t%5Bresize%5D%5Bheight%5D=100&accessToken=8c1bea837a4a3eda71213a8f90877770620bb5c8917abf61caa8b8a04bdee760');
 		});
 
 		it('should support specifying engine', () => {
@@ -24,7 +24,18 @@ describe('getResizedImageUrl', () => {
 			};
 			const newUrl = getResizedImageUrl(url, targetSize, {}, 'secret', {engine: 'sharp'});
 
-			assert.deepEqual(newUrl, 'https://smooth-storage-dev.aptoma.no/users/dn/images/986914.jpg?engine=sharp&t%5Bresize%5D%5Bwidth%5D=100&t%5Bresize%5D%5Bheight%5D=100&t%5Bstrip%5D=true&accessToken=7a916cbd7a81ba2d26c5119e0051234a42af054c943a0611623a20caa8c63c26');
+			assert.deepEqual(newUrl, 'https://smooth-storage-dev.aptoma.no/users/dn/images/986914.jpg?engine=sharp&t%5Bstrip%5D=true&t%5Bresize%5D%5Bwidth%5D=100&t%5Bresize%5D%5Bheight%5D=100&accessToken=42e9de4d7340ad910bbae73357300deb6e8d47069f574738389eb5992c9f8274');
+		});
+
+		it('should support not using strip', () => {
+			const url = 'https://smooth-storage-dev.aptoma.no/users/dn/images/986914.jpg';
+			const targetSize = {
+				width: 100,
+				height: 100
+			};
+			const newUrl = getResizedImageUrl(url, targetSize, {strip: false}, 'secret');
+
+			assert.deepEqual(newUrl, 'https://smooth-storage-dev.aptoma.no/users/dn/images/986914.jpg?t%5Bresize%5D%5Bwidth%5D=100&t%5Bresize%5D%5Bheight%5D=100&accessToken=b15bd5e493437291e1f3d013e63ca47914a3b519824394befd2da010d4e3b08e');
 		});
 	});
 });


### PR DESCRIPTION
We need to keep color profiles for print, so we can't use `strip`.